### PR TITLE
JFUIE-155 fixes bug in modal headers

### DIFF
--- a/src/components/JfCodeModalComponent/index.vue
+++ b/src/components/JfCodeModalComponent/index.vue
@@ -9,7 +9,7 @@
         @hidden="_afterModalHidden"
         >
         <template slot="modal-title">
-            <h4 class="modal-title" id="popup-header" v-html="title"></h4>
+            <div id="popup-header" v-html="title"></div>
         </template>
 
         <p v-if="beforeMessage" v-html="beforeMessage"></p>

--- a/src/components/JfConfirmModalComponent/index.vue
+++ b/src/components/JfConfirmModalComponent/index.vue
@@ -1,7 +1,7 @@
 <template>
     <b-modal v-bind="modalProps" @hide="_handleHide" @hidden="_afterModalHidden">
         <template slot="modal-title">
-            <h4 class="modal-title" id="popup-header" v-html="title"></h4>
+            <div id="popup-header" v-html="title"></div>
         </template>
         <template slot="modal-footer">
                 <jf-checkbox v-if="checkboxLabel"

--- a/src/components/JfFullTextModalComponent/index.vue
+++ b/src/components/JfFullTextModalComponent/index.vue
@@ -10,7 +10,7 @@
         @hidden="_afterModalHidden"
         >
         <template slot="modal-title">
-            <h3 class="modal-title" id="popup-header">{{title}}</h3>
+            <div id="popup-header">{{title}}</div>
         </template>
 
         <div class="modal-body simple-text" v-if="text">


### PR DESCRIPTION
The modal-title slot automatically adds a h5 element so the explicit addition of h5 is not necessary