### PR TITLE
bugfix to allow nocursor option for mobile view

### DIFF
--- a/src/directives/jf_codemirror/jf_codemirror.js
+++ b/src/directives/jf_codemirror/jf_codemirror.js
@@ -42,7 +42,7 @@ class jfCodeController {
 
         this.editorOptions = {
             lineNumbers: true,
-            readOnly: this.allowEdit, // Don't use nocursor - it disables search
+            readOnly: this.allowEdit, // enables nocursor usage if provided in the params for mobile layout
             lineWrapping: true,
             mode: this.mode || 'links',
             viewportMargin: 65,

--- a/src/directives/jf_codemirror/jf_codemirror.js
+++ b/src/directives/jf_codemirror/jf_codemirror.js
@@ -7,7 +7,8 @@ export function jfCodeMirror() {
             mimeType: '@',
             mode: '@',
             model: '=',
-            allowEdit: '@',
+            allowEdit: '=',
+            noCursor: '=',
             height: '@?',
             apiAccess: '=',
             autofocus: '@',
@@ -40,9 +41,18 @@ class jfCodeController {
 	    this._formatModel();
 	    this.autofocus = this.autofocus === 'true';
 
+        console.log(this);
+
+        let readOnlyParam = !this.allowEdit;
+        
+        if(!_.isUndefined(this.noCursor) && this.noCursor) {
+            readOnlyParam = 'nocursor';
+        }
+
+
         this.editorOptions = {
             lineNumbers: true,
-            readOnly: this.allowEdit, // enables nocursor usage if provided in the params for mobile layout
+            readOnly: readOnlyParam, // enables nocursor usage if provided in the params for mobile layout
             lineWrapping: true,
             mode: this.mode || 'links',
             viewportMargin: 65,

--- a/src/directives/jf_codemirror/jf_codemirror.js
+++ b/src/directives/jf_codemirror/jf_codemirror.js
@@ -7,7 +7,7 @@ export function jfCodeMirror() {
             mimeType: '@',
             mode: '@',
             model: '=',
-            allowEdit: '=',
+            allowEdit: '@',
             height: '@?',
             apiAccess: '=',
             autofocus: '@',
@@ -42,7 +42,7 @@ class jfCodeController {
 
         this.editorOptions = {
             lineNumbers: true,
-            readOnly: !this.allowEdit, // Don't use nocursor - it disables search
+            readOnly: this.allowEdit, // Don't use nocursor - it disables search
             lineWrapping: true,
             mode: this.mode || 'links',
             viewportMargin: 65,

--- a/src/directives/jf_codemirror/jf_codemirror.js
+++ b/src/directives/jf_codemirror/jf_codemirror.js
@@ -40,15 +40,16 @@ class jfCodeController {
     $onInit() {
 	    this._formatModel();
 	    this.autofocus = this.autofocus === 'true';
-        let readOnlyParam = !this.allowEdit;
+        let isReadOnlyMode = !this.allowEdit;
 
+        // enables nocursor usage if provided in the params for mobile layout
         if(!_.isUndefined(this.noCursor) && this.noCursor) {
-            readOnlyParam = 'nocursor';
+            isReadOnlyMode = 'nocursor';
         }
 
         this.editorOptions = {
             lineNumbers: true,
-            readOnly: readOnlyParam, // enables nocursor usage if provided in the params for mobile layout
+            readOnly: isReadOnlyMode, 
             lineWrapping: true,
             mode: this.mode || 'links',
             viewportMargin: 65,

--- a/src/directives/jf_codemirror/jf_codemirror.js
+++ b/src/directives/jf_codemirror/jf_codemirror.js
@@ -40,15 +40,11 @@ class jfCodeController {
     $onInit() {
 	    this._formatModel();
 	    this.autofocus = this.autofocus === 'true';
-
-        console.log(this);
-
         let readOnlyParam = !this.allowEdit;
-        
+
         if(!_.isUndefined(this.noCursor) && this.noCursor) {
             readOnlyParam = 'nocursor';
         }
-
 
         this.editorOptions = {
             lineNumbers: true,


### PR DESCRIPTION
changed the binding of the `allow-edit` param to allow the`nocursor` option as the mobile versions are editable currently(although the param says `allow-edit=false`)